### PR TITLE
Improve error handling

### DIFF
--- a/src/api/getHarvestParams.ts
+++ b/src/api/getHarvestParams.ts
@@ -2,11 +2,10 @@ import { Hex } from 'viem';
 import { StakewiseConnector } from '../internal/connector';
 
 export const getHarvestParams = async (connector: StakewiseConnector, vault: Hex) => {
-    try {
-        const harvestData = await connector.graphqlRequest({
-            type: 'graph',
-            op: 'HarvestParams',
-            query: `
+    const harvestData = await connector.graphqlRequest({
+        type: 'graph',
+        op: 'HarvestParams',
+        query: `
             query HarvestParams($address: ID!) {
             harvestParams: vault(id: $address) {
                 proof
@@ -16,20 +15,13 @@ export const getHarvestParams = async (connector: StakewiseConnector, vault: Hex
               }
             }
             `,
-            variables: {
-                address: vault.toLowerCase(),
-            },
-            onSuccess: (value: { data: any }) => value,
-            onError: function (reason: any): PromiseLike<never> {
-                throw new Error(`Failed to get harvest from Stakewise: ${reason}`);
-            },
-        });
+        variables: {
+            address: vault.toLowerCase(),
+        },
+    });
 
-        if (!harvestData.data.harvestParams) {
-            throw new Error('Vault data is missing the harvestParams field');
-        }
-        return harvestData.data.harvestParams;
-    } catch (error) {
-        throw new Error(`Error retrieving harvest params data: ${error instanceof Error ? error.message : error}`);
+    if (!harvestData.data.harvestParams) {
+        throw new Error('Vault data is missing the harvestParams field');
     }
+    return harvestData.data.harvestParams;
 };

--- a/src/api/getHarvestParams.ts
+++ b/src/api/getHarvestParams.ts
@@ -2,29 +2,42 @@ import { Hex } from 'viem';
 import { StakewiseConnector } from '../internal/connector';
 
 export const getHarvestParams = async (connector: StakewiseConnector, vault: Hex) => {
-    const harvestResponse = await connector.graphqlRequest({
-        type: 'graph',
-        op: 'HarvestParams',
-        query: `
-        query HarvestParams($address: ID!) {
-        harvestParams: vault(id: $address) {
-            proof
-            rewardsRoot
-            reward: proofReward
-            unlockedMevReward: proofUnlockedMevReward
-          }
+    try {
+        const harvestResponse = await connector.graphqlRequest({
+            type: 'graph',
+            op: 'HarvestParams',
+            query: `
+            query HarvestParams($address: ID!) {
+            harvestParams: vault(id: $address) {
+                proof
+                rewardsRoot
+                reward: proofReward
+                unlockedMevReward: proofUnlockedMevReward
+              }
+            }
+            `,
+            variables: {
+                address: vault.toLowerCase(),
+            },
+            onSuccess: function (value: Response) {
+                return value;
+            },
+            onError: function (reason: any): PromiseLike<never> {
+                throw new Error(`Failed to get harvest from Stakewise: ${reason}`);
+            },
+        });
+        if (!harvestResponse.ok) {
+            throw new Error('Invalid response from Stakewise');
         }
-        `,
-        variables: {
-            address: vault.toLowerCase(),
-        },
-        onSuccess: function (value: Response) {
-            return value;
-        },
-        onError: function (reason: any): PromiseLike<never> {
-            throw new Error(`Failed to get harvest from Stakewise: ${reason}`);
-        },
-    });
-    const harvestData = await harvestResponse.json();
-    return harvestData.data.harvestParams;
+        const harvestData = await harvestResponse.json();
+        if (harvestData.errors && harvestData.errors.length) {
+            throw new Error(harvestData.errors[0].message);
+        }
+        if (!harvestData.data || !harvestData.data.harvestParams) {
+            throw new Error('Vault data is missing or incomplete');
+        }
+        return harvestData.data.harvestParams;
+    } catch (error) {
+        throw new Error(`Error retrieving harvest params data: ${error instanceof Error ? error.message : error}`);
+    }
 };

--- a/src/api/getHarvestParams.ts
+++ b/src/api/getHarvestParams.ts
@@ -3,7 +3,7 @@ import { StakewiseConnector } from '../internal/connector';
 
 export const getHarvestParams = async (connector: StakewiseConnector, vault: Hex) => {
     try {
-        const harvestResponse = await connector.graphqlRequest({
+        const harvestData = await connector.graphqlRequest({
             type: 'graph',
             op: 'HarvestParams',
             query: `
@@ -19,22 +19,14 @@ export const getHarvestParams = async (connector: StakewiseConnector, vault: Hex
             variables: {
                 address: vault.toLowerCase(),
             },
-            onSuccess: function (value: Response) {
-                return value;
-            },
+            onSuccess: (value: { data: any }) => value,
             onError: function (reason: any): PromiseLike<never> {
                 throw new Error(`Failed to get harvest from Stakewise: ${reason}`);
             },
         });
-        if (!harvestResponse.ok) {
-            throw new Error('Invalid response from Stakewise');
-        }
-        const harvestData = await harvestResponse.json();
-        if (harvestData.errors && harvestData.errors.length) {
-            throw new Error(harvestData.errors[0].message);
-        }
-        if (!harvestData.data || !harvestData.data.harvestParams) {
-            throw new Error('Vault data is missing or incomplete');
+
+        if (!harvestData.data.harvestParams) {
+            throw new Error('Vault data is missing the harvestParams field');
         }
         return harvestData.data.harvestParams;
     } catch (error) {

--- a/src/api/rewardsHistory.ts
+++ b/src/api/rewardsHistory.ts
@@ -15,36 +15,50 @@ async function extractVaultUserRewards(
         user: allocatorAddress.toLowerCase(),
         dateFrom: Math.floor(dateFrom.getTime() / 1000).toString(),
     };
-    const responseRewards = await connector.graphqlRequest({
-        type: 'api',
-        op: 'UserRewards',
-        query: `query UserRewards($user: String!, $vaultAddress: String!, $dateFrom: DateAsTimestamp!) { userRewards(user: $user, vaultAddress: $vaultAddress, dateFrom: $dateFrom) { date, sumRewards, }}`,
-        variables: vars_getRewards,
-        onSuccess: function (value: Response): Response {
-            return value;
-        },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        onError: function (reason: any): PromiseLike<never> {
-            throw new Error(`Failed to get rewards from Stakewise: ${reason}`);
-        },
-    });
-
-    const rewardsData = await responseRewards.json();
-    const dataPoints: RewardsDataPoint[] = [];
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    rewardsData.data.userRewards.forEach((reward: any) => {
-        const when: Date = new Date(parseInt(reward.date) * 1000);
-        if (when <= dateTo) {
-            const sumRewards: string = reward.sumRewards;
-            dataPoints.push({
-                when: when,
-                amount: BigInt(sumRewards),
-                vault: vault,
-            });
+    try {
+        const responseRewards = await connector.graphqlRequest({
+            type: 'api',
+            op: 'UserRewards',
+            query: `query UserRewards($user: String!, $vaultAddress: String!, $dateFrom: DateAsTimestamp!) { userRewards(user: $user, vaultAddress: $vaultAddress, dateFrom: $dateFrom) { date, sumRewards, }}`,
+            variables: vars_getRewards,
+            onSuccess: function (value: Response): Response {
+                return value;
+            },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            onError: function (reason: any): PromiseLike<never> {
+                throw new Error(`Failed to get rewards from Stakewise: ${reason}`);
+            },
+        });
+        if (!responseRewards.ok) {
+            throw new Error('Invalid response from Stakewise');
         }
-    });
+        const rewardsData = await responseRewards.json();
 
-    return dataPoints;
+        if (rewardsData.errors && rewardsData.errors.length) {
+            throw new Error(rewardsData.errors[0].message);
+        }
+
+        if (!rewardsData.data || !rewardsData.data.userRewards || rewardsData.data.userRewards.length === 0) {
+            throw new Error('Rewards data is missing or incomplete');
+        }
+        const dataPoints: RewardsDataPoint[] = [];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        rewardsData.data.userRewards.forEach((reward: any) => {
+            const when: Date = new Date(parseInt(reward.date) * 1000);
+            if (when <= dateTo) {
+                const sumRewards: string = reward.sumRewards;
+                dataPoints.push({
+                    when: when,
+                    amount: BigInt(sumRewards),
+                    vault: vault,
+                });
+            }
+        });
+
+        return dataPoints;
+    } catch (error) {
+        throw new Error(`Error retrieving rewards history data: ${error instanceof Error ? error.message : error}`);
+    }
 }
 
 export default async function rewardsHistory(

--- a/src/api/rewardsHistory.ts
+++ b/src/api/rewardsHistory.ts
@@ -15,42 +15,32 @@ async function extractVaultUserRewards(
         user: allocatorAddress.toLowerCase(),
         dateFrom: Math.floor(dateFrom.getTime() / 1000).toString(),
     };
-    try {
-        const rewardsData = await connector.graphqlRequest({
-            type: 'api',
-            op: 'UserRewards',
-            query: `query UserRewards($user: String!, $vaultAddress: String!, $dateFrom: DateAsTimestamp!) { userRewards(user: $user, vaultAddress: $vaultAddress, dateFrom: $dateFrom) { date, sumRewards, }}`,
-            variables: vars_getRewards,
-            onSuccess: (value: { data: any }) => value,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            onError: function (reason: any): PromiseLike<never> {
-                throw new Error(`Failed to get rewards from Stakewise: ${reason}`);
-            },
-        });
 
-        if (!rewardsData.data.userRewards || rewardsData.data.userRewards.length === 0) {
-            throw new Error(
-                `Rewards data is missing the userRewards field or the field is empty ${rewardsData.data.userRewards}`,
-            );
-        }
-        const dataPoints: RewardsDataPoint[] = [];
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        rewardsData.data.userRewards.forEach((reward: any) => {
-            const when: Date = new Date(parseInt(reward.date) * 1000);
-            if (when <= dateTo) {
-                const sumRewards: string = reward.sumRewards;
-                dataPoints.push({
-                    when: when,
-                    amount: BigInt(sumRewards),
-                    vault: vault,
-                });
-            }
-        });
+    const rewardsData = await connector.graphqlRequest({
+        type: 'api',
+        op: 'UserRewards',
+        query: `query UserRewards($user: String!, $vaultAddress: String!, $dateFrom: DateAsTimestamp!) { userRewards(user: $user, vaultAddress: $vaultAddress, dateFrom: $dateFrom) { date, sumRewards, }}`,
+        variables: vars_getRewards,
+    });
 
-        return dataPoints;
-    } catch (error) {
-        throw new Error(`Error retrieving rewards history data: ${error instanceof Error ? error.message : error}`);
+    if (!rewardsData.data.userRewards || rewardsData.data.userRewards.length === 0) {
+        throw new Error(`Rewards data is missing the userRewards field or the field is empty`);
     }
+    const dataPoints: RewardsDataPoint[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    rewardsData.data.userRewards.forEach((reward: any) => {
+        const when: Date = new Date(parseInt(reward.date) * 1000);
+        if (when <= dateTo) {
+            const sumRewards: string = reward.sumRewards;
+            dataPoints.push({
+                when: when,
+                amount: BigInt(sumRewards),
+                vault: vault,
+            });
+        }
+    });
+
+    return dataPoints;
 }
 
 export default async function rewardsHistory(
@@ -62,17 +52,14 @@ export default async function rewardsHistory(
     },
 ): Promise<Array<RewardsDataPoint>> {
     let vaultRewards: RewardsDataPoint[] = [];
-    try {
-        vaultRewards = await extractVaultUserRewards(
-            pool.connector,
-            request.vault,
-            pool.userAccount,
-            request.from,
-            request.to,
-        );
-    } catch (error) {
-        throw new Error(`Failed to get rewards: ${error}`);
-    }
+
+    vaultRewards = await extractVaultUserRewards(
+        pool.connector,
+        request.vault,
+        pool.userAccount,
+        request.from,
+        request.to,
+    );
 
     return vaultRewards;
 }

--- a/src/api/transactionsHistory.ts
+++ b/src/api/transactionsHistory.ts
@@ -18,46 +18,36 @@ async function extractTransactionsHistory(
         first: 1000,
         skip: 0,
     };
-    try {
-        const actionsData = await connector.graphqlRequest({
-            type: 'graph',
-            op: 'AllocatorActions',
-            query: `
+
+    const actionsData = await connector.graphqlRequest({
+        type: 'graph',
+        op: 'AllocatorActions',
+        query: `
         query AllocatorActions( $skip: Int! $first: Int! $where: AllocatorAction_filter) 
             { 
             allocatorActions( skip: $skip, first: $first, orderBy: createdAt, orderDirection: desc, where: $where, ) 
             { id assets createdAt actionType }}
         `,
-            variables: vars_getActions,
-            onSuccess: (value: { data: any }) => value,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            onError: function (reason: any): PromiseLike<never> {
-                throw new Error(`Failed to get vault from Stakewise: ${reason}`);
-            },
-        });
+        variables: vars_getActions,
+    });
 
-        if (!actionsData.data.allocatorActions || actionsData.data.allocatorActions.length === 0) {
-            throw new Error(
-                `Transaction data is missing the allocatorActions field or the field is empty ${actionsData.data.allocatorActions}`,
-            );
-        }
-        const interactions: VaultTransaction[] = [];
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        actionsData.data.allocatorActions.forEach((action: any) => {
-            const createdAt: string = action.createdAt;
-            interactions.push({
-                vault: vault,
-                when: new Date(parseInt(createdAt) * 1000),
-                type: action.actionType,
-                amount: action.assets ? BigInt(action.assets) : 0n, // some txs don't have assets, e.g. ExitQueueEntered
-                hash: action.id,
-            });
-        });
-
-        return interactions;
-    } catch (error) {
-        throw new Error(`Error retrieving transaction history: ${error instanceof Error ? error.message : error}`);
+    if (!actionsData.data.allocatorActions || actionsData.data.allocatorActions.length === 0) {
+        throw new Error(`Transaction data is missing the allocatorActions field or the field is empty`);
     }
+    const interactions: VaultTransaction[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    actionsData.data.allocatorActions.forEach((action: any) => {
+        const createdAt: string = action.createdAt;
+        interactions.push({
+            vault: vault,
+            when: new Date(parseInt(createdAt) * 1000),
+            type: action.actionType,
+            amount: action.assets ? BigInt(action.assets) : 0n, // some txs don't have assets, e.g. ExitQueueEntered
+            hash: action.id,
+        });
+    });
+
+    return interactions;
 }
 
 export default async function transactionsHistory(pool: OpusPool, vaults: Hex[]): Promise<Array<VaultTransaction>> {

--- a/src/api/vaultDetails.ts
+++ b/src/api/vaultDetails.ts
@@ -24,11 +24,10 @@ async function extractVaultProperties(connector: StakewiseConnector, vault: Hex)
     dateBeforeYesterday.setDate(dateBeforeYesterday.getDate() - 8);
     today.setDate(today.getDate());
 
-    try {
-        const vaultData = await connector.graphqlRequest({
-            type: 'graph',
-            op: 'Vault',
-            query: `
+    const vaultData = await connector.graphqlRequest({
+        type: 'graph',
+        op: 'Vault',
+        query: `
             query Vault($address: ID!) {
               vault(id: $address) {
                 address: id
@@ -60,21 +59,13 @@ async function extractVaultProperties(connector: StakewiseConnector, vault: Hex)
                 address
               }
             }`,
-            variables: vars_getVault,
-            onSuccess: (value: { data: any }) => value,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            onError: function (reason: any): PromiseLike<never> {
-                throw new Error(`Failed to get vault from Stakewise: ${reason}`);
-            },
-        });
+        variables: vars_getVault,
+    });
 
-        if (!vaultData.data.vault) {
-            throw new Error(`Vault data is missing the vault field ${vaultData.data}`);
-        }
-        return { vaultData: vaultData.data };
-    } catch (error) {
-        throw new Error(`Error retrieving vault data: ${error instanceof Error ? error.message : error}`);
+    if (!vaultData.data.vault) {
+        throw new Error(`Vault data is missing the vault field`);
     }
+    return { vaultData: vaultData.data };
 }
 
 // Get latest balance and cached properties

--- a/src/api/vaultDetails.ts
+++ b/src/api/vaultDetails.ts
@@ -25,7 +25,7 @@ async function extractVaultProperties(connector: StakewiseConnector, vault: Hex)
     today.setDate(today.getDate());
 
     try {
-        const responseVault = await connector.graphqlRequest({
+        const vaultData = await connector.graphqlRequest({
             type: 'graph',
             op: 'Vault',
             query: `
@@ -61,25 +61,15 @@ async function extractVaultProperties(connector: StakewiseConnector, vault: Hex)
               }
             }`,
             variables: vars_getVault,
-            onSuccess: function (value: Response): Response {
-                return value;
-            },
+            onSuccess: (value: { data: any }) => value,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             onError: function (reason: any): PromiseLike<never> {
                 throw new Error(`Failed to get vault from Stakewise: ${reason}`);
             },
         });
-        if (!responseVault.ok) {
-            throw new Error('Invalid response from Stakewise');
-        }
-        const vaultData = await responseVault.json();
 
-        if (vaultData.errors && vaultData.errors.length > 0) {
-            throw new Error(vaultData.errors[0].message);
-        }
-
-        if (!vaultData.data || !vaultData.data.vault) {
-            throw new Error('Vault data is missing or incomplete');
+        if (!vaultData.data.vault) {
+            throw new Error(`Vault data is missing the vault field ${vaultData.data}`);
         }
         return { vaultData: vaultData.data };
     } catch (error) {

--- a/src/internal/connector.ts
+++ b/src/internal/connector.ts
@@ -9,9 +9,6 @@ export interface GraphQLRequest {
     query: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     variables: any;
-    onSuccess: (value: { data: any }) => { data: any };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    onError: (reason: any) => PromiseLike<never>;
 }
 
 // Connector abstraction, providing on-chain and GraphQL API primitives
@@ -95,7 +92,7 @@ export class StakewiseConnector {
     }
 
     // Perform graphQL request
-    graphqlRequest = (request: GraphQLRequest): Promise<{ data: any }> => {
+    graphqlRequest = async (request: GraphQLRequest): Promise<{ data: any }> => {
         const body: string = JSON.stringify({
             operationName: request.op,
             query: request.query.trim(),
@@ -123,21 +120,18 @@ export class StakewiseConnector {
         }
 
         const endpoint = `${uri}?opName=${request.op}`;
-        return fetch(endpoint, params)
-            .then(async (response) => {
-                if (!response.ok) {
-                    throw new Error('Invalid response from Stakewise');
-                }
-                const responseData = await response.json();
+        const response = await fetch(endpoint, params);
+        if (!response.ok) {
+            throw new Error(`Invalid response from Stakewise. Endpoint: ${endpoint}`);
+        }
+        const responseData = await response.json();
 
-                if (responseData.errors && responseData.errors.length) {
-                    throw new Error(responseData.errors[0].message);
-                }
-                if (!responseData.data) {
-                    throw new Error('Response from Stakewise is missing data');
-                }
-                return request.onSuccess(responseData);
-            })
-            .catch(request.onError);
+        if (responseData.errors && responseData.errors.length) {
+            throw new Error(responseData.errors[0].message);
+        }
+        if (!responseData.data) {
+            throw new Error('Response from Stakewise is missing data');
+        }
+        return responseData;
     };
 }

--- a/tests/burnOsToken.test.ts
+++ b/tests/burnOsToken.test.ts
@@ -22,9 +22,9 @@ const AMOUNT_TO_MINT = parseEther('15');
 const originalFetch = global.fetch;
 let callCount = 0; // Track the number of calls to the specific URL
 
-// on first call, there are no minted shares
-// make the second call after minting AMOUNT_TO_MINT shares
-// make the third call after burning all shares
+// on first call, there are no minted shares (shares: 0)
+// make the second call after minting AMOUNT_TO_MINT shares (shares: minted_amount)
+// make the third call after burning all shares (shares: minted_amount - burned_amount)
 const mockFetch = jest.fn().mockImplementation((input, init) => {
     if (input === 'https://holesky-graph.stakewise.io/subgraphs/name/stakewise/stakewise?opName=OsTokenPositions') {
         callCount += 1; // Increment call count for the specific URL

--- a/tests/errorHandling.test.ts
+++ b/tests/errorHandling.test.ts
@@ -1,0 +1,271 @@
+import { Networks, OpusPool } from '../src';
+import { getHarvestParams } from '../src/api/getHarvestParams';
+
+const VAULT_ADDRESS = '0xd68AF28AeE9536144d4B9B6C0904CAf7E794B3D3';
+const USER_ADDRESS = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
+
+const originalFetch = global.fetch;
+let osTokenPositionsCount = 0;
+let vaultCount = 0;
+let userRewardsCount = 0;
+let allocatorActionsCount = 0;
+let harvestParamsCount = 0;
+
+const mockFetch = jest.fn().mockImplementation((input, init) => {
+    // OsTokenPositions:
+    // on first call, return ok: false
+    // 2nd call, return ok: true, errors field in response with message
+    // 3rd call: return ok: true, no data field in response
+    // 4th call: return ok: true, empty osTokenPositions array
+    if (input === 'https://holesky-graph.stakewise.io/subgraphs/name/stakewise/stakewise?opName=OsTokenPositions') {
+        osTokenPositionsCount += 1;
+        switch (osTokenPositionsCount) {
+            case 1:
+                return Promise.resolve({
+                    ok: false,
+                });
+            case 2:
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ errors: [{ message: 'Test error message' }] }),
+                });
+            case 3:
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({}),
+                });
+            case 4:
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ data: { osTokenPositions: [] } }),
+                });
+            default:
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ data: { osTokenPositions: [{ shares: '0' }] } }),
+                });
+        }
+        // Vault:
+        // 1: return ok: false
+        // 2: missing vault field in response
+    } else if (input === 'https://holesky-graph.stakewise.io/subgraphs/name/stakewise/stakewise?opName=Vault') {
+        vaultCount += 1;
+        switch (vaultCount) {
+            case 1:
+                return Promise.resolve({
+                    ok: false,
+                });
+            default:
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ data: {} }),
+                });
+        }
+    } else if (input === 'https://holesky-api.stakewise.io/graphql?opName=UserRewards') {
+        userRewardsCount += 1; // Increment call count for the specific URL
+        switch (userRewardsCount) {
+            case 1:
+                return Promise.resolve({
+                    ok: false,
+                });
+            default:
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ data: {} }),
+                });
+        }
+        // AllocatorActions
+    } else if (
+        input === 'https://holesky-graph.stakewise.io/subgraphs/name/stakewise/stakewise?opName=AllocatorActions'
+    ) {
+        allocatorActionsCount += 1;
+        switch (allocatorActionsCount) {
+            case 1:
+                return Promise.resolve({
+                    ok: false,
+                });
+            case 2:
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ data: { allocatorActions: [] } }),
+                });
+            default:
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ data: {} }),
+                });
+        }
+    } else if (input === 'https://holesky-api.stakewise.io/graphql?opName=HarvestParams') {
+        harvestParamsCount += 1;
+        switch (harvestParamsCount) {
+            case 1:
+                return Promise.resolve({
+                    ok: false,
+                });
+            default:
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ data: {} }),
+                });
+        }
+    } else {
+        return originalFetch(input, init); // Fallback to the original fetch for other URLs
+    }
+});
+
+global.fetch = mockFetch;
+
+describe('OsTokenPositions', () => {
+    it('returns the correct error', async () => {
+        const pool = new OpusPool({
+            address: USER_ADDRESS,
+            network: Networks.Hardhat,
+        });
+        // 1st call
+        await pool
+            .getOsTokenPositionForVault(VAULT_ADDRESS)
+            .then((res) => res)
+            .catch((err) => {
+                expect(err).toBeInstanceOf(Error);
+                expect(err.message).toBe(
+                    'Invalid response from Stakewise. Endpoint: https://holesky-graph.stakewise.io/subgraphs/name/stakewise/stakewise?opName=OsTokenPositions',
+                );
+            });
+        // 2nd call
+        await pool
+            .getOsTokenPositionForVault(VAULT_ADDRESS)
+            .then((res) => res)
+            .catch((err) => {
+                expect(err).toBeInstanceOf(Error);
+                expect(err.message).toBe('Test error message');
+            });
+        // 3rd call
+        await pool
+            .getOsTokenPositionForVault(VAULT_ADDRESS)
+            .then((res) => res)
+            .catch((err) => {
+                expect(err).toBeInstanceOf(Error);
+                expect(err.message).toBe('Response from Stakewise is missing data');
+            });
+        // 4th call
+        await pool
+            .getOsTokenPositionForVault(VAULT_ADDRESS)
+            .then((res) => res)
+            .catch((err) => {
+                expect(err).toBeInstanceOf(Error);
+                expect(err.message).toBe(
+                    'Minted shares data is missing the osTokenPositions field or the field is empty',
+                );
+            });
+    });
+});
+
+describe('Vault', () => {
+    it('returns the correct error', async () => {
+        const pool = new OpusPool({
+            address: USER_ADDRESS,
+            network: Networks.Hardhat,
+        });
+        await pool
+            .getVaultDetails([VAULT_ADDRESS])
+            .then((res) => res)
+            .catch((err) => {
+                expect(err).toBeInstanceOf(Error);
+                expect(err.message).toBe(
+                    'Invalid response from Stakewise. Endpoint: https://holesky-graph.stakewise.io/subgraphs/name/stakewise/stakewise?opName=Vault',
+                );
+            });
+        await pool
+            .getVaultDetails([VAULT_ADDRESS])
+            .then((res) => res)
+            .catch((err) => {
+                expect(err).toBeInstanceOf(Error);
+                expect(err.message).toBe('Vault data is missing the vault field');
+            });
+    });
+});
+
+describe('AllocatorActions', () => {
+    it('returns the correct error', async () => {
+        const pool = new OpusPool({
+            address: USER_ADDRESS,
+            network: Networks.Hardhat,
+        });
+        await pool
+            .getTransactionsHistory([VAULT_ADDRESS])
+            .then((res) => res)
+            .catch((err) => {
+                expect(err).toBeInstanceOf(Error);
+                expect(err.message).toBe(
+                    'Invalid response from Stakewise. Endpoint: https://holesky-graph.stakewise.io/subgraphs/name/stakewise/stakewise?opName=AllocatorActions',
+                );
+            });
+        await pool
+            .getTransactionsHistory([VAULT_ADDRESS])
+            .then((res) => res)
+            .catch((err) => {
+                expect(err).toBeInstanceOf(Error);
+                expect(err.message).toBe(
+                    'Transaction data is missing the allocatorActions field or the field is empty',
+                );
+            });
+    });
+});
+
+describe('UserRewards', () => {
+    it('returns the correct error', async () => {
+        const pool = new OpusPool({
+            address: USER_ADDRESS,
+            network: Networks.Hardhat,
+        });
+        await pool
+            .getRewardsHistory({
+                from: new Date('2023-11-25'),
+                to: new Date('2023-12-08'),
+                vault: VAULT_ADDRESS,
+            })
+            .then((res) => res)
+            .catch((err) => {
+                expect(err).toBeInstanceOf(Error);
+                expect(err.message).toBe(
+                    'Invalid response from Stakewise. Endpoint: https://holesky-api.stakewise.io/graphql?opName=UserRewards',
+                );
+            });
+        await pool
+            .getRewardsHistory({
+                from: new Date('2023-11-25'),
+                to: new Date('2023-12-08'),
+                vault: VAULT_ADDRESS,
+            })
+            .then((res) => res)
+            .catch((err) => {
+                expect(err).toBeInstanceOf(Error);
+                expect(err.message).toBe('Rewards data is missing the userRewards field or the field is empty');
+            });
+    });
+});
+
+describe('HarvestParams', () => {
+    it('returns the correct error', async () => {
+        const pool = new OpusPool({
+            address: USER_ADDRESS,
+            network: Networks.Hardhat,
+        });
+        await getHarvestParams(pool.connector, VAULT_ADDRESS)
+            .then((res) => res)
+            .catch((err) => {
+                expect(err).toBeInstanceOf(Error);
+                expect(err.message).toBe(
+                    'Invalid response from Stakewise. Endpoint: https://holesky-api.stakewise.io/graphql?opName=HarvestParams',
+                );
+            });
+        await getHarvestParams(pool.connector, VAULT_ADDRESS)
+            .then((res) => res)
+            .catch((err) => {
+                expect(err).toBeInstanceOf(Error);
+                expect(err.message).toBe(
+                    'Harvest params data is missing the harvestParams field or the field is empty',
+                );
+            });
+    });
+});

--- a/tests/unstake.test.ts
+++ b/tests/unstake.test.ts
@@ -20,6 +20,21 @@ const AMOUNT_TO_STAKE = parseEther('5');
 const AMOUNT_TO_UNSTAKE = parseEther('4');
 const AMOUNT_TO_UNSTAKE_TOO_MUCH = parseEther('500');
 
+const originalFetch = global.fetch;
+
+const mockFetch = jest.fn().mockImplementation((input, init) => {
+    if (input === 'https://holesky-graph.stakewise.io/subgraphs/name/stakewise/stakewise?opName=OsTokenPositions') {
+        return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ data: { osTokenPositions: [{ shares: '0' }] } }), // No minted shares
+        });
+    } else {
+        return originalFetch(input, init); // Fallback to the original fetch for other URLs
+    }
+});
+
+global.fetch = mockFetch;
+
 describe('Unstaking Integration Test', () => {
     let USER_ADDRESS: Hex;
     let walletClientWithBalance: WalletClient;


### PR DESCRIPTION
Return an error in these scenarios:
- the response status is 200, but it contains an `errors` field
- the data field is missing
- the fields for the response that are supposed to be arrays have length 0

Test fixes:
Now that we return errors for length 0 arrays, we need to mock graphql responses for certain tests