### PR TITLE
Remove check for empty array in error handling

### DIFF
--- a/src/api/rewardsHistory.ts
+++ b/src/api/rewardsHistory.ts
@@ -23,8 +23,8 @@ async function extractVaultUserRewards(
         variables: vars_getRewards,
     });
 
-    if (!rewardsData.data.userRewards || rewardsData.data.userRewards.length === 0) {
-        throw new Error(`Rewards data is missing the userRewards field or the field is empty`);
+    if (!rewardsData.data.userRewards) {
+        throw new Error(`Rewards data is missing the userRewards field`);
     }
     const dataPoints: RewardsDataPoint[] = [];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/api/transactionsHistory.ts
+++ b/src/api/transactionsHistory.ts
@@ -32,7 +32,7 @@ async function extractTransactionsHistory(
     });
 
     if (!actionsData.data.allocatorActions || actionsData.data.allocatorActions.length === 0) {
-        throw new Error(`Transaction data is missing the allocatorActions field or the field is empty`);
+        throw new Error(`Transaction data is missing the allocatorActions field`);
     }
     const interactions: VaultTransaction[] = [];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/internal/osTokenRequests.ts
+++ b/src/internal/osTokenRequests.ts
@@ -147,8 +147,8 @@ export const getOsTokenPosition = async (pool: OpusPool, vaultAddress: Hex): Pro
         },
     });
 
-    if (!gqlMintedSharesJson.data.osTokenPositions || gqlMintedSharesJson.data.osTokenPositions.length === 0) {
-        throw new Error(`Minted shares data is missing the osTokenPositions field or the field is empty`);
+    if (!gqlMintedSharesJson.data.osTokenPositions) {
+        throw new Error(`Minted shares data is missing the osTokenPositions field`);
     }
     const gqlMintedShares = BigInt(gqlMintedSharesJson.data.osTokenPositions[0]?.shares || 0);
 

--- a/tests/errorHandling.test.ts
+++ b/tests/errorHandling.test.ts
@@ -37,7 +37,7 @@ const mockFetch = jest.fn().mockImplementation((input, init) => {
             case 4:
                 return Promise.resolve({
                     ok: true,
-                    json: () => Promise.resolve({ data: { osTokenPositions: [] } }),
+                    json: () => Promise.resolve({ data: {} }),
                 });
             default:
                 return Promise.resolve({
@@ -153,9 +153,7 @@ describe('OsTokenPositions', () => {
             .then((res) => res)
             .catch((err) => {
                 expect(err).toBeInstanceOf(Error);
-                expect(err.message).toBe(
-                    'Minted shares data is missing the osTokenPositions field or the field is empty',
-                );
+                expect(err.message).toBe('Minted shares data is missing the osTokenPositions field');
             });
     });
 });
@@ -205,9 +203,7 @@ describe('AllocatorActions', () => {
             .then((res) => res)
             .catch((err) => {
                 expect(err).toBeInstanceOf(Error);
-                expect(err.message).toBe(
-                    'Transaction data is missing the allocatorActions field or the field is empty',
-                );
+                expect(err.message).toBe('Transaction data is missing the allocatorActions field');
             });
     });
 });
@@ -240,7 +236,7 @@ describe('UserRewards', () => {
             .then((res) => res)
             .catch((err) => {
                 expect(err).toBeInstanceOf(Error);
-                expect(err.message).toBe('Rewards data is missing the userRewards field or the field is empty');
+                expect(err.message).toBe('Rewards data is missing the userRewards field');
             });
     });
 });
@@ -263,9 +259,7 @@ describe('HarvestParams', () => {
             .then((res) => res)
             .catch((err) => {
                 expect(err).toBeInstanceOf(Error);
-                expect(err.message).toBe(
-                    'Harvest params data is missing the harvestParams field or the field is empty',
-                );
+                expect(err.message).toBe('Harvest params data is missing the harvestParams field');
             });
     });
 });


### PR DESCRIPTION
The check for empty field would return a false error for users that did not yet mint any os tokens
**Fix:** 
remove the check for empty arrays