### PR TITLE
Allow gas estimation for total balance when stake

### DIFF
--- a/src/api/stake.ts
+++ b/src/api/stake.ts
@@ -39,8 +39,6 @@ export default async function stake(
                     unlockedMevReward: harvestParams.unlockedMevReward,
                 },
             ],
-            maxFeePerGas,
-            maxPriorityFeePerGas,
         });
         tx = encodeFunctionData({
             abi: VaultABI,
@@ -64,8 +62,6 @@ export default async function stake(
             value: request.amount,
             address: request.vault,
             account: pool.userAccount,
-            maxFeePerGas,
-            maxPriorityFeePerGas,
         });
         tx = encodeFunctionData({
             abi: VaultABI,

--- a/tests/stake.test.ts
+++ b/tests/stake.test.ts
@@ -128,4 +128,21 @@ describe('Staking Integration Test', () => {
         const { assets: assetsAfterStaking } = await pool.getStakeBalanceForUser(VAULT_ADDRESS);
         expect(assetsAfterStaking).toEqual(initialAssets + AMOUNT_TO_STAKE);
     });
+    test('User can estimate gas with max amount', async () => {
+        const pool = new OpusPool({
+            address: USER_ADDRESS,
+            network: Networks.Hardhat,
+        });
+
+        const { assets: initialAssets } = await pool.getStakeBalanceForUser(VAULT_ADDRESS);
+        const initialBalance: bigint = await publicClient.getBalance({
+            address: USER_ADDRESS,
+        });
+
+        const stakeTransactionData = await pool.buildStakeTransaction({
+            vault: VAULT_ADDRESS,
+            amount: initialBalance,
+        });
+        expect(stakeTransactionData.gasEstimation).toBeGreaterThan(0);
+    });
 });


### PR DESCRIPTION
Whenever we want to estimate the gas for staking maximum amount,  we need to remove maxFeePerGas and maxPriorityFeePerGas from gas estimation. Otherwise it results in an error and it's not possible to accurately estimate how much user can stake.