### PR TITLE
Update graphql queries

### DIFF
--- a/src/api/transactionsHistory.ts
+++ b/src/api/transactionsHistory.ts
@@ -2,6 +2,7 @@ import { OpusPool } from '..';
 import { VaultTransaction } from '../types/transaction';
 import { StakewiseConnector } from '../internal/connector';
 import { Hex } from 'viem';
+import { VaultActionType } from '../types/enums';
 
 async function extractTransactionsHistory(
     connector: StakewiseConnector,
@@ -13,7 +14,7 @@ async function extractTransactionsHistory(
             vault_: {
                 id: vault.toLowerCase(),
             },
-            address: allocatorAddress.toLowerCase(),
+            actionType_in: Object.values(VaultActionType),
         },
         first: 1000,
         skip: 0,
@@ -23,10 +24,25 @@ async function extractTransactionsHistory(
         type: 'graph',
         op: 'AllocatorActions',
         query: `
-        query AllocatorActions( $skip: Int! $first: Int! $where: AllocatorAction_filter) 
-            { 
-            allocatorActions( skip: $skip, first: $first, orderBy: createdAt, orderDirection: desc, where: $where, ) 
-            { id assets createdAt actionType }}
+        query AllocatorActions(
+            $skip: Int!
+            $first: Int!
+            $where: AllocatorAction_filter
+            ) {
+            allocatorActions(
+                skip: $skip,
+                first: $first,
+                orderBy: createdAt,
+                orderDirection: desc,
+                where: $where,
+            ) {
+                id
+                assets
+                shares
+                createdAt
+                actionType
+            }
+        }
         `,
         variables: vars_getActions,
     });

--- a/src/api/vaultDetails.ts
+++ b/src/api/vaultDetails.ts
@@ -29,9 +29,10 @@ async function extractVaultProperties(connector: StakewiseConnector, vault: Hex)
         op: 'Vault',
         query: `
             query Vault($address: ID!) {
-              vault(id: $address) {
+            vault(id: $address) {
                 address: id
                 performance: score
+                apy
                 admin
                 isErc20
                 imageUrl
@@ -43,6 +44,7 @@ async function extractVaultProperties(connector: StakewiseConnector, vault: Hex)
                 tokenName
                 feePercent
                 totalAssets
+                isBlocklist
                 displayName
                 description
                 whitelister
@@ -50,15 +52,12 @@ async function extractVaultProperties(connector: StakewiseConnector, vault: Hex)
                 tokenSymbol
                 feeRecipient
                 validatorsRoot
-                weeklyApy
-              }
-              privateVaultAccounts(
-                where: { vault: $address }
-              ) {
-                createdAt
-                address
-              }
-            }`,
+                blocklistCount
+                whitelistCount
+                blocklistManager
+            }
+            }
+        `,
         variables: vars_getVault,
     });
 
@@ -114,7 +113,7 @@ async function extractVaultDetails(
         description: vaultData.vault.description,
         logoUrl: vaultData.vault.imageUrl,
         tvl: BigInt(vaultData.vault.totalAssets),
-        apy: vaultData.vault.weeklyApy > 0 ? vaultData.vault.weeklyApy : '0',
+        apy: vaultData.vault.apy > 0 ? vaultData.vault.apy : '0',
         balance: assets,
     };
 }

--- a/src/internal/defaultVaults.ts
+++ b/src/internal/defaultVaults.ts
@@ -10,7 +10,7 @@ import { Networks } from '../types/enums';
 export function getDefaultVaults(network: Networks): Array<Hex> {
     switch (network) {
         case Networks.Holesky:
-            return ['0xd68af28aee9536144d4b9b6c0904caf7e794b3d3', '0x95d0db03d59658e1af0d977ecfe142f178930ac5'];
+            return ['0x95d0db03d59658e1af0d977ecfe142f178930ac5'];
         case Networks.Ethereum:
             return ['0xe6d8d8ac54461b1c5ed15740eee322043f696c08'];
         case Networks.Hardhat:

--- a/tests/meta.test.ts
+++ b/tests/meta.test.ts
@@ -86,8 +86,25 @@ describe('interactionHistory', () => {
         const defaultVaults = getDefaultVaults(params.network);
         const interactions: VaultTransaction[] = await pool.getTransactionsHistory(defaultVaults);
 
-        expect(toObject(interactions)).toBe(
-            '[{"vault":"0xe6d8d8ac54461b1c5ed15740eee322043f696c08","when":"2023-11-28T11:38:11.000Z","type":"Deposited","amount":"50000000000000000","hash":"0xf265f7aa11bb45643eafecfddb013ffd68ef42bda618f3e07d2668da8261d084-171"}]',
+        const expectedInteraction = {
+            vault: '0xe6d8d8ac54461b1c5ed15740eee322043f696c08',
+            when: '2023-11-28T11:38:11.000Z',
+            type: 'Deposited',
+            amount: '50000000000000000',
+            hash: '0xf265f7aa11bb45643eafecfddb013ffd68ef42bda618f3e07d2668da8261d084-171',
+        };
+
+        const interactionExists = interactions.find(
+            (interaction) =>
+                interaction.vault === expectedInteraction.vault &&
+                interaction.when.getDate() === 28 &&
+                interaction.when.getMonth() === 10 && // month is 0-based
+                interaction.when.getFullYear() === 2023 &&
+                interaction.type === expectedInteraction.type &&
+                interaction.amount.toString() === expectedInteraction.amount &&
+                interaction.hash === expectedInteraction.hash,
         );
+
+        expect(interactionExists).toBeTruthy();
     });
 });


### PR DESCRIPTION
The `AllocatorActions` has been modified - it will return all txs for the vault 
In this pr we're removing the private `holesky` vault address, since it's not being used. 