### PR TITLE
Trigger testing workflow every day

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: Node.js CI
 
-on: [push]
+on:
+    push:
+    schedule:
+        # Runs at 00:00 (midnight) UTC every day
+        - cron: '0 0 * * *'
 
 jobs:
     build:


### PR DESCRIPTION
## Problem

We've experienced issues in our SDK when StakeWise introduces breaking changes - to prevent this and be notified early we'd like to run e2e tests regularly

## Proposed solution

Run tests daily via the cron job, subscribe to failing job events